### PR TITLE
feat: Vercelデプロイ監視用ヘルスチェックエンドポイント追加

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -94,13 +94,14 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/all_in_one_test
 
-      # Vercelデプロイの確認（Preview環境）
-      - name: Wait for Vercel Preview
+      # Vercelデプロイの確認（Preview環境、ヘルスチェックエンドポイントで確認）
+      - name: Wait for Vercel Preview with Health Check
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 600
+          path: '/api/health' # ヘルスチェックエンドポイントを直接チェック
           # deployブランチのプレビューURLを待機
 
       - name: Preview Deploy Summary

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -95,14 +95,15 @@ jobs:
           path: .next/
           retention-days: 7
 
-      # Vercel本番デプロイの確認
-      - name: Wait for Vercel Production
+      # Vercel本番デプロイの確認（ヘルスチェックエンドポイントで確認）
+      - name: Wait for Vercel Production with Health Check
         uses: patrickedqvist/wait-for-vercel-preview@v1.3.2
         id: waitForVercel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max_timeout: 600
           environment: production
+          path: '/api/health' # ヘルスチェックエンドポイントを直接チェック
 
       - name: Production Deploy Summary
         run: |

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { prisma } from '@/lib/prisma'
+
+/**
+ * GET /api/health
+ *
+ * ヘルスチェック用エンドポイント
+ * Vercelデプロイ後の疎通確認やGitHub Actionsでの監視に使用
+ * 認証不要で誰でもアクセス可能
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    // データベース接続チェック
+    let databaseStatus = 'disconnected'
+    try {
+      // 軽量なクエリでデータベース接続を確認
+      await prisma.$queryRaw`SELECT 1`
+      databaseStatus = 'connected'
+    } catch {
+      // データベース接続エラーは握りつぶして、ステータスのみ反映
+      databaseStatus = 'error'
+    }
+
+    // パッケージ情報からバージョンを取得
+    const packageJson = await import('../../../../package.json')
+    const version = packageJson.version || '1.0.0'
+
+    // 成功レスポンス
+    return NextResponse.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'all-in-one-api',
+      version,
+      database: databaseStatus,
+    })
+  } catch (error) {
+    // 予期しないエラーが発生した場合
+    // eslint-disable-next-line no-console
+    console.error('Health check error:', error)
+    return NextResponse.json(
+      {
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        service: 'all-in-one-api',
+        error: 'Internal server error',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/tests/unit/app/api/health/route.test.ts
+++ b/tests/unit/app/api/health/route.test.ts
@@ -1,0 +1,136 @@
+import { NextRequest } from 'next/server'
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { GET } from '@/app/api/health/route'
+import { prisma } from '@/lib/prisma'
+
+// prismaのモック
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+}))
+
+// package.jsonのモック
+vi.mock('../../../../../package.json', () => ({
+  version: '1.2.3',
+}))
+
+/**
+ * GET /api/health のテスト
+ *
+ * テスト対象:
+ * - ヘルスチェックレスポンスの形式
+ * - データベース接続状態の確認
+ * - エラーハンドリング
+ * - 認証不要でのアクセス
+ */
+describe('GET /api/health', () => {
+  const mockRequest = new NextRequest('http://localhost:3000/api/health')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    // console.errorのモック
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      // 空の実装
+    })
+  })
+
+  it('正常時はstatus: okとデータベース接続状態を返す', async () => {
+    // データベース接続が成功する場合のテスト
+    // Arrange
+    const mockQueryRaw = vi.fn().mockResolvedValueOnce([{ '?column?': 1 }])
+    ;(prisma.$queryRaw as any) = mockQueryRaw
+
+    // Act
+    const response = await GET(mockRequest)
+    const data = await response.json()
+
+    // Assert
+    expect(response.status).toBe(200)
+    expect(data).toMatchObject({
+      status: 'ok',
+      service: 'all-in-one-api',
+      version: '1.2.3',
+      database: 'connected',
+    })
+    expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    expect(mockQueryRaw).toHaveBeenCalledWith(['SELECT 1'])
+  })
+
+  it('データベース接続エラー時はdatabase: errorを返す', async () => {
+    // データベース接続が失敗する場合でもAPIは正常レスポンスを返す
+    // Arrange
+    const mockQueryRaw = vi.fn().mockRejectedValueOnce(new Error('Connection failed'))
+    ;(prisma.$queryRaw as any) = mockQueryRaw
+
+    // Act
+    const response = await GET(mockRequest)
+    const data = await response.json()
+
+    // Assert
+    expect(response.status).toBe(200)
+    expect(data).toMatchObject({
+      status: 'ok',
+      service: 'all-in-one-api',
+      version: '1.2.3',
+      database: 'error',
+    })
+  })
+
+
+  it('認証なしでアクセス可能である', async () => {
+    // 認証ヘッダーなしでもアクセスできることを確認
+    // Arrange
+    const mockQueryRaw = vi.fn().mockResolvedValueOnce([{ '?column?': 1 }])
+    ;(prisma.$queryRaw as any) = mockQueryRaw
+    const unauthenticatedRequest = new NextRequest('http://localhost:3000/api/health')
+
+    // Act
+    const response = await GET(unauthenticatedRequest)
+
+    // Assert
+    expect(response.status).toBe(200)
+    // 認証チェック関数が呼ばれないことを暗黙的に確認（モックしていないため）
+  })
+})
+
+describe('GET /api/health - エラーハンドリング', () => {
+  const mockRequest = new NextRequest('http://localhost:3000/api/health')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // console.errorのモック
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      // 空の実装
+    })
+  })
+
+  it('予期しないエラー時は500エラーを返す', async () => {
+    // ヘルスチェック処理自体でエラーが発生した場合
+    // Arrange
+    const mockQueryRaw = vi.fn().mockRejectedValueOnce(new Error('Database error'))
+    ;(prisma.$queryRaw as any) = mockQueryRaw
+    
+    // package.jsonのインポートでエラーを発生させる
+    vi.doMock('../../../../../package.json', () => {
+      throw new Error('Unexpected error')
+    })
+
+    // Act
+    const response = await GET(mockRequest)
+    const data = await response.json()
+
+    // Assert
+    expect(response.status).toBe(500)
+    expect(data).toMatchObject({
+      status: 'error',
+      service: 'all-in-one-api',
+      error: 'Internal server error',
+    })
+    expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    expect(console.error).toHaveBeenCalledWith('Health check error:', expect.any(Error))
+  })
+})

--- a/tests/unit/app/api/health/route.test.ts
+++ b/tests/unit/app/api/health/route.test.ts
@@ -80,7 +80,6 @@ describe('GET /api/health', () => {
     })
   })
 
-
   it('認証なしでアクセス可能である', async () => {
     // 認証ヘッダーなしでもアクセスできることを確認
     // Arrange
@@ -113,7 +112,7 @@ describe('GET /api/health - エラーハンドリング', () => {
     // Arrange
     const mockQueryRaw = vi.fn().mockRejectedValueOnce(new Error('Database error'))
     ;(prisma.$queryRaw as any) = mockQueryRaw
-    
+
     // package.jsonのインポートでエラーを発生させる
     vi.doMock('../../../../../package.json', () => {
       throw new Error('Unexpected error')

--- a/tests/unit/modules/ingredients/server/application/queries/get-ingredients.handler.test.ts
+++ b/tests/unit/modules/ingredients/server/application/queries/get-ingredients.handler.test.ts
@@ -5,8 +5,8 @@ import { GetIngredientsHandler } from '@/modules/ingredients/server/application/
 import { GetIngredientsQuery } from '@/modules/ingredients/server/application/queries/get-ingredients.query'
 import type { IngredientRepository } from '@/modules/ingredients/server/domain/repositories/ingredient-repository.interface'
 
-import { IngredientBuilder } from '../../../../__fixtures__/builders/entities/ingredient.builder'
-import { testDataHelpers } from '../../../../__fixtures__/builders/faker.config'
+import { IngredientBuilder } from '../../../../../../__fixtures__/builders/entities/ingredient.builder'
+import { testDataHelpers } from '../../../../../../__fixtures__/builders/faker.config'
 
 describe('GetIngredientsHandler', () => {
   let handler: GetIngredientsHandler
@@ -50,8 +50,10 @@ describe('GetIngredientsHandler', () => {
     ]
 
     // モックの設定
-    vi.mocked(mockRepository.findMany).mockResolvedValue(ingredients)
-    vi.mocked(mockRepository.count).mockResolvedValue(2)
+    const findManyMock = mockRepository.findMany as ReturnType<typeof vi.fn>
+    const countMock = mockRepository.count as ReturnType<typeof vi.fn>
+    findManyMock.mockResolvedValue(ingredients)
+    countMock.mockResolvedValue(2)
 
     // クエリの実行
     const userId = testDataHelpers.userId()
@@ -68,7 +70,7 @@ describe('GetIngredientsHandler', () => {
 
     // リポジトリの呼び出し確認
     expect(mockRepository.findMany).toHaveBeenCalledWith({
-      userId: userId,
+      userId,
       page: 1,
       limit: 20,
       search: undefined,
@@ -78,7 +80,7 @@ describe('GetIngredientsHandler', () => {
       sortOrder: undefined,
     })
     expect(mockRepository.count).toHaveBeenCalledWith({
-      userId: userId,
+      userId,
       search: undefined,
       categoryId: undefined,
       expiryStatus: undefined,
@@ -93,8 +95,10 @@ describe('GetIngredientsHandler', () => {
       .withDefaultStock()
       .build()
 
-    vi.mocked(mockRepository.findMany).mockResolvedValue([ingredient])
-    vi.mocked(mockRepository.count).mockResolvedValue(1)
+    const findManyMock = mockRepository.findMany as ReturnType<typeof vi.fn>
+    const countMock = mockRepository.count as ReturnType<typeof vi.fn>
+    findManyMock.mockResolvedValue([ingredient])
+    countMock.mockResolvedValue(1)
 
     const userId = testDataHelpers.userId()
     const query = new GetIngredientsQuery(userId, 1, 20, 'トマト', categoryId, 'expired')
@@ -102,11 +106,11 @@ describe('GetIngredientsHandler', () => {
 
     expect(result.items).toHaveLength(1)
     expect(mockRepository.findMany).toHaveBeenCalledWith({
-      userId: userId,
+      userId,
       page: 1,
       limit: 20,
       search: 'トマト',
-      categoryId: categoryId,
+      categoryId,
       expiryStatus: 'expired',
       sortBy: undefined,
       sortOrder: undefined,
@@ -119,8 +123,10 @@ describe('GetIngredientsHandler', () => {
       new IngredientBuilder().withRandomName().withDefaultStock().build(),
     ]
 
-    vi.mocked(mockRepository.findMany).mockResolvedValue(ingredients)
-    vi.mocked(mockRepository.count).mockResolvedValue(2)
+    const findManyMock = mockRepository.findMany as ReturnType<typeof vi.fn>
+    const countMock = mockRepository.count as ReturnType<typeof vi.fn>
+    findManyMock.mockResolvedValue(ingredients)
+    countMock.mockResolvedValue(2)
 
     const userId = testDataHelpers.userId()
     const query = new GetIngredientsQuery(
@@ -137,7 +143,7 @@ describe('GetIngredientsHandler', () => {
 
     expect(result.items).toHaveLength(2)
     expect(mockRepository.findMany).toHaveBeenCalledWith({
-      userId: userId,
+      userId,
       page: 1,
       limit: 20,
       search: undefined,
@@ -149,8 +155,10 @@ describe('GetIngredientsHandler', () => {
   })
 
   it('空の結果を返すことができる', async () => {
-    vi.mocked(mockRepository.findMany).mockResolvedValue([])
-    vi.mocked(mockRepository.count).mockResolvedValue(0)
+    const findManyMock = mockRepository.findMany as ReturnType<typeof vi.fn>
+    const countMock = mockRepository.count as ReturnType<typeof vi.fn>
+    findManyMock.mockResolvedValue([])
+    countMock.mockResolvedValue(0)
 
     const userId = testDataHelpers.userId()
     const query = new GetIngredientsQuery(userId, 1, 20)


### PR DESCRIPTION
## 概要

Vercelのデプロイ状態をGitHub Actionsで監視するため、認証不要のヘルスチェックエンドポイント `/api/health` を追加しました。

## 変更内容

### 新機能
- **ヘルスチェックエンドポイント**: `/api/health`
  - サービス状態、タイムスタンプ、バージョン情報を返却
  - データベース接続状態の確認機能
  - 認証不要でアクセス可能

### GitHub Actions連携
- `patrickedqvist/wait-for-vercel-preview@v1.3.2` の `path` パラメータでヘルスチェックエンドポイントを指定
- プロダクション環境 (`production-deploy.yml`) とブランチ環境 (`deploy-branch.yml`) の両方で使用

### テスト
- 4つのテストケースで包括的にカバー:
  - 正常時のレスポンス確認
  - データベース接続エラー時の挙動
  - 予期しないエラー時の500レスポンス
  - 認証不要でのアクセス確認

### その他の修正
- `get-ingredients.handler.test.ts` を正しいディレクトリ構造に移動
- ESLintの `@typescript-eslint/unbound-method` エラーを修正

## API仕様

**エンドポイント**: `GET /api/health`

**レスポンス例（正常時）**:
```json
{
  "status": "ok",
  "timestamp": "2024-06-28T04:00:00.000Z",
  "service": "all-in-one-api",
  "version": "0.1.0",
  "database": "connected"
}
```

**レスポンス例（エラー時）**:
```json
{
  "status": "error",
  "timestamp": "2024-06-28T04:00:00.000Z",
  "service": "all-in-one-api",
  "error": "Internal server error"
}
```

## テスト結果

✅ 全テストが成功  
✅ TypeScriptコンパイル通過  
✅ Prettier形式チェック通過  

🤖 Generated with [Claude Code](https://claude.ai/code)